### PR TITLE
Fix hotkey parsing bug

### DIFF
--- a/Server.py
+++ b/Server.py
@@ -73,7 +73,7 @@ def handle_client(conn, addr, u_name):
                 str = str.replace("`", "\n")
                 pyautogui.write(str[1:], interval = 0.05)
                 continue
-        if str[0]== '!' and str[1 == '!']:
+        if str[0]== '!' and str[1] == '!':
             spl = str[2:].split('~')
             if len(spl)==1:
                 pyautogui.hotkey(spl[0])


### PR DESCRIPTION
## Summary
- fix typo in `Server.py` hotkey detection logic

## Testing
- `python -m py_compile Server.py client.py utility.py streamVideo.py`

------
https://chatgpt.com/codex/tasks/task_e_685568f4442c832a9284f622d92a0e76